### PR TITLE
find-by-id

### DIFF
--- a/lib/items_repo.rb
+++ b/lib/items_repo.rb
@@ -29,4 +29,10 @@ class ItemsRepo
     @items
   end
 
+  def find_by_id (id)
+    @items.find do |item|
+      item.id == id
+    end
+  end
+
 end

--- a/test/items_repo_test.rb
+++ b/test/items_repo_test.rb
@@ -20,9 +20,13 @@ class ItemsRepoTest < Minitest::Test
   end
 
   def test_it_can_gather_all_items
-    @repo.all
     assert_instance_of Item, @repo.all[0]
     assert_instance_of Item, @repo.all[-1]
     assert_equal 1367, @repo.all.length
+  end
+
+  def test_it_can_find_by_id
+    assert_instance_of Item, @repo.find_by_id("263395237")
+    assert_nil @repo.find_by_id("111111")
   end
 end


### PR DESCRIPTION
# Add 
### `lib/items_repo`
- `find_by_id`: will return either `nil` or an `item` object 
### `test/items_repo`
- `test_it_can_find_by_id`: **PASSES**

closes #4 